### PR TITLE
Usuarios conectados desde todos los chats

### DIFF
--- a/app/assets/javascripts/channels/chat/chat.coffee
+++ b/app/assets/javascripts/channels/chat/chat.coffee
@@ -15,6 +15,7 @@ ready = ->
 		params
 		{
 			connected: ->
+				@perform 'speak', { connected_user: $('#user').text() }
 
 			received: (data) ->
 				message = ''
@@ -27,13 +28,15 @@ ready = ->
 				else
 					message += "<div align='center'>"
 
-				if data.picture?
+				if data.active_users_ping
+					@perform 'speak', { connected_user: $('#user').text() }
+				else if data.picture?
 					message += "<img src='#{data.picture.href}' height='80%' width='80%'/>"
 				else if data.audio?
 					message += "<audio controls><source src='#{data.audio.href}' type='audio/ogg'></audio>"
-				else
+				else if data.message
 					message += "#{data.message}"
-							
+
 				message += "</div>"
 
 				$('#messages').append(message)

--- a/app/channels/chat_channel.rb
+++ b/app/channels/chat_channel.rb
@@ -1,0 +1,14 @@
+class ChatChannel < ApplicationCable::Channel
+	def subscribed
+		stream_from "home:users"
+	end
+
+	def unsubscribed
+	end
+
+	def speak(data)
+		if data['connected_user']
+			ActionCable.server.broadcast "home:users", data
+		end
+	end
+end

--- a/app/channels/group_channel.rb
+++ b/app/channels/group_channel.rb
@@ -1,12 +1,15 @@
-class GroupChannel < ApplicationCable::Channel
+class GroupChannel < ChatChannel
 	def subscribed
+		super
 		stream_from "group#{params['group']}:messages"
 	end
 
 	def unsubscribed
+		super
 	end
 
 	def speak(data)
+		super(data)
 		GroupMessage.create(:id_group => params['group'], :from => data['from'], :content => data['message'], :messageType => 'text')
 		ActionCable.server.broadcast "group#{params['group']}:messages", { from: data['from'], message: data['message'] }
 	end

--- a/app/channels/lobby_channel.rb
+++ b/app/channels/lobby_channel.rb
@@ -1,12 +1,15 @@
-class LobbyChannel < ApplicationCable::Channel
+class LobbyChannel < ChatChannel
 	def subscribed
+		super
 		stream_from "lobby:messages"
 	end
 
 	def unsubscribed
+		super
 	end
 
 	def speak(data)
+		super(data)
 		LobbyMessage.create(:from => data['from'], :content => data['message'], :messageType => 'text')
 		ActionCable.server.broadcast "lobby:messages", { from: data['from'], message: data['message'] }
 	end

--- a/app/channels/private_channel.rb
+++ b/app/channels/private_channel.rb
@@ -1,13 +1,16 @@
-class PrivateChannel < ApplicationCable::Channel
+class PrivateChannel < ChatChannel
 	def subscribed
+		super
 		stream_from "private::#{current_user}::#{params['to']}::messages"
 	end
 
 	def unsubscribed
+		super
 	end
 
 	def speak(data)
-    	PrivateMessage.create({:from => data['from'], :to => data['to'], :content => data['message'], :messageType => 'text'})
+		super(data)
+  	PrivateMessage.create({:from => data['from'], :to => data['to'], :content => data['message'], :messageType => 'text'})
 		ActionCable.server.broadcast "private::#{current_user}::#{params['to']}::messages", {from: data['from'], to: data['to'], message: data['message']}
 		ActionCable.server.broadcast "private::#{params['to']}::#{current_user}::messages", {from: data['from'], to: data['to'], message: data['message']}
 	end

--- a/app/views/chat/chat.html.erb
+++ b/app/views/chat/chat.html.erb
@@ -2,6 +2,8 @@
 
 <%= button_to('Salir', "/home", method: "get") %>
 
+<div id="user" style="display: none;"><%= cookies.encrypted[:user] %></div>
+
 <% if @channelType == 'GroupChannel' %>
     <h2>Grupo: <%= @group.name %></h2>
 <% elsif @channelType == 'LobbyChannel'%>


### PR DESCRIPTION
- Cuando se entra al lobby, a un grupo o chat privado se manda el evento de usuario desconectado. Esto hace que los que esten escuchando desde la home lo pierdan de su lista.
- Agrego que todos los chats manden siempre el evento de usuario conectado al entrar, cosa de que los usuarios que esten en la home puedan seguir hablando con estos.